### PR TITLE
main.py运行在windows下报错问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+##[2026-03-02]修护main.py在windows下的报错`loop.add_signal_handler(sig, signal_handler) NotImplementedError`
+
 ## [2026-02-28] 账户持仓表格化显示 + 订单成交更新
 
 ### 新增

--- a/main.py
+++ b/main.py
@@ -656,8 +656,11 @@ async def main(args=None):
         for task in asyncio.all_tasks(loop):
             task.cancel()
     
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, signal_handler)
+    try:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, signal_handler)
+    except NotImplementedError:
+        pass
     
     try:
         await scraper.run()


### PR DESCRIPTION
loop.add_signal_handler() 只能在：

Linux

macOS

使用。

在 Windows 上：

asyncio 不支持信号注册

会直接抛出 NotImplementedError


推荐改成：

try:
    for sig in (signal.SIGINT, signal.SIGTERM):
        loop.add_signal_handler(sig, signal_handler)
except NotImplementedError:
    pass

这样：

Linux 正常

Windows 自动跳过

不报错