### PR TITLE
docs: 替换失效的长桥接入指南链接为官网链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ python3 main.py
 - ✅ 风险控制和 Dry Run 模式
 - ✅ 完整的测试流程
 
-**查看完整接入指南**：[LONGPORT_INTEGRATION_GUIDE.md](./doc/LONGPORT_INTEGRATION_GUIDE.md)
+详细 API 说明请参考 [长桥 OpenAPI 官方文档](https://open.longbridge.com/zh-CN/)。
 
 快速开始：
 


### PR DESCRIPTION
## 背景

README 中引用的 `doc/LONGPORT_INTEGRATION_GUIDE.md` 已在 commit 791100f (`chore: delete unused code`) 中被删除,链接失效。

## 改动

将死链替换为长桥 OpenAPI 官网链接 [open.longbridge.com](https://open.longbridge.com/zh-CN/)。

## 理由

- 原文档内容(开户、App Key/Secret/Token、`.env` 配置、paper/real 切换、dry_run 等)README 自身已经覆盖
- 指向官网,不会随本项目实现变动而过时

仅 1 行改动,不影响任何代码。

(Replaces #3)