### PR TITLE
docs: 修正 .env.example 中正股页面的示例 URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ PAGES=[
     },
     {
         "name":"正股页面",
-        "url":"https://whop.com/joined/stock-and-option/-JG1I58S5zTHbxs/app/",
+        "url":"https://whop.com/joined/stock-and-option/-GiWyN1ZTuUjwlG/app/",
         "type":"stock"
     }
 ]


### PR DESCRIPTION
## 背景

`.env.example` 中正股页面的示例 URL 为 `-JG1I58S5zTHbxs`,但 README 的"导出页面消息"章节中给出的正股页示例 URL 是 `-GiWyN1ZTuUjwlG`,两者不一致。

实测 `-JG1I58S5zTHbxs` 会导致 `EnhancedMessageExtractor` 返回 0 条消息(页面 DOM 与正股频道实际结构不匹配);切换到 `-GiWyN1ZTuUjwlG` 后恢复正常。

## 改动

将 `.env.example` 中正股页面的 URL 统一为 `-GiWyN1ZTuUjwlG`,和 README 示例保持一致。

## 验证

本地 `python3 main.py` 选择正股页面后,能正常抓取并解析消息流。